### PR TITLE
Add postprocess: sigmoid and tanh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(tests
   test/pipeline_test.cc
   test/quantize_test.cc
   test/relu_test.cc
+  test/sigmoid_test.cc
   intgemm.cc
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(tests
   test/quantize_test.cc
   test/relu_test.cc
   test/sigmoid_test.cc
+  test/tanh_test.cc
   intgemm.cc
 )
 

--- a/aligned.h
+++ b/aligned.h
@@ -22,6 +22,9 @@ template <class T> class AlignedVector {
     T *end() { return mem_ + size_; }
     const T *end() const { return mem_ + size_; }
 
+    template <typename ReturnType>
+    ReturnType *as() { return reinterpret_cast<ReturnType*>(mem_); }
+
   private:
     T *mem_;
     std::size_t size_;

--- a/intrinsics.h
+++ b/intrinsics.h
@@ -51,6 +51,9 @@ INTGEMM_SSE2 static inline __m128i cvtps_epi32(__m128 arg) {
 INTGEMM_SSE2 static inline __m128i cvttps_epi32(__m128 a) {
   return _mm_cvttps_epi32(a);
 }
+INTGEMM_SSE2 static inline __m128 div_ps(__m128 a, __m128 b) {
+  return _mm_div_ps(a, b);
+}
 /*
  * Missing i32gather_ps for SSE2
  */
@@ -125,6 +128,9 @@ INTGEMM_AVX2 static inline __m256i cvtps_epi32(__m256 arg) {
 }
 INTGEMM_AVX2 static inline __m256i cvttps_epi32(__m256 a) {
   return _mm256_cvttps_epi32(a);
+}
+INTGEMM_AVX2 static inline __m256 div_ps(__m256 a, __m256 b) {
+  return _mm256_div_ps(a, b);
 }
 INTGEMM_AVX2 static inline __m256 i32gather_ps(float const *base_addr, __m256i vindex, const int scale) {
   return _mm256_i32gather_ps(base_addr, vindex, scale);
@@ -202,6 +208,9 @@ INTGEMM_AVX512BW static inline __m512i cvtps_epi32(__m512 arg) {
 }
 INTGEMM_AVX512BW static inline __m512i cvttps_epi32(__m512 a) {
   return _mm512_cvttps_epi32(a);
+}
+INTGEMM_AVX512BW static inline __m512 div_ps(__m512 a, __m512 b) {
+  return _mm512_div_ps(a, b);
 }
 INTGEMM_AVX512BW static inline __m512 i32gather_ps(float const *base_addr, __m512i vindex, const int scale) {
   return _mm512_i32gather_ps(vindex, base_addr, scale);

--- a/intrinsics.h
+++ b/intrinsics.h
@@ -36,6 +36,9 @@ INTGEMM_SSE2 static inline __m128i add_epi32(__m128i first, __m128i second) {
 INTGEMM_SSE2 static inline __m128i adds_epi16(__m128i first, __m128i second) {
   return _mm_adds_epi16(first, second);
 }
+INTGEMM_SSE2 static inline __m128 add_ps(__m128 a, __m128 b) {
+  return _mm_add_ps(a, b);
+}
 INTGEMM_SSE2 static inline __m128 and_ps(__m128 first, __m128 second) {
   return _mm_and_ps(first, second);
 }
@@ -45,6 +48,12 @@ INTGEMM_SSE2 static inline __m128 cvtepi32_ps(__m128i arg) {
 INTGEMM_SSE2 static inline __m128i cvtps_epi32(__m128 arg) {
   return _mm_cvtps_epi32(arg);
 }
+INTGEMM_SSE2 static inline __m128i cvttps_epi32(__m128 a) {
+  return _mm_cvttps_epi32(a);
+}
+/*
+ * Missing i32gather_ps for SSE2
+ */
 template <> INTGEMM_SSE2 inline __m128 loadu_ps(const float* mem_addr) {
   return _mm_loadu_ps(mem_addr);
 }
@@ -56,6 +65,9 @@ INTGEMM_SSSE3 static inline __m128i maddubs_epi16(__m128i first, __m128i second)
 }
 INTGEMM_SSE2 static inline __m128 max_ps(__m128 first, __m128 second) {
   return _mm_max_ps(first, second);
+}
+INTGEMM_SSE2 static inline __m128 min_ps(__m128 a, __m128 b) {
+  return _mm_min_ps(a, b);
 }
 INTGEMM_SSE2 static inline __m128 mul_ps(__m128 a, __m128 b) {
   return _mm_mul_ps(a, b);
@@ -81,8 +93,8 @@ INTGEMM_SSSE3 static inline __m128i sign_epi8(__m128i first, __m128i second) {
 INTGEMM_SSE2 static inline void storeu_ps(float* mem_addr, __m128 a) {
   _mm_storeu_ps(mem_addr, a);
 }
-INTGEMM_SSE2 static inline __m128 add_ps (__m128 a, __m128 b) {
-  return _mm_add_ps(a, b);
+INTGEMM_SSE2 static inline __m128 sub_ps(__m128 a, __m128 b) {
+  return _mm_sub_ps(a, b);
 }
 
 /*
@@ -99,6 +111,9 @@ INTGEMM_AVX2 static inline __m256i add_epi32(__m256i first, __m256i second) {
 INTGEMM_AVX2 static inline __m256i adds_epi16(__m256i first, __m256i second) {
   return _mm256_adds_epi16(first, second);
 }
+INTGEMM_AVX2 static inline __m256 add_ps(__m256 a, __m256 b) {
+  return _mm256_add_ps(a, b);
+}
 INTGEMM_AVX2 static inline __m256 and_ps(__m256 first, __m256 second) {
   return _mm256_and_ps(first, second);
 }
@@ -107,6 +122,12 @@ INTGEMM_AVX2 static inline __m256 cvtepi32_ps(__m256i arg) {
 }
 INTGEMM_AVX2 static inline __m256i cvtps_epi32(__m256 arg) {
   return _mm256_cvtps_epi32(arg);
+}
+INTGEMM_AVX2 static inline __m256i cvttps_epi32(__m256 a) {
+  return _mm256_cvttps_epi32(a);
+}
+INTGEMM_AVX2 static inline __m256 i32gather_ps(float const *base_addr, __m256i vindex, const int scale) {
+  return _mm256_i32gather_ps(base_addr, vindex, scale);
 }
 template <> INTGEMM_AVX2 inline __m256 loadu_ps(const float* mem_addr) {
   return _mm256_loadu_ps(mem_addr);
@@ -119,6 +140,9 @@ INTGEMM_AVX2 static inline __m256i maddubs_epi16(__m256i first, __m256i second) 
 }
 INTGEMM_AVX2 static inline __m256 max_ps(__m256 first, __m256 second) {
   return _mm256_max_ps(first, second);
+}
+INTGEMM_AVX2 static inline __m256 min_ps(__m256 a, __m256 b) {
+  return _mm256_min_ps(a, b);
 }
 INTGEMM_AVX2 static inline __m256 mul_ps(__m256 a, __m256 b) {
   return _mm256_mul_ps(a, b);
@@ -144,8 +168,8 @@ INTGEMM_AVX2 static inline __m256i sign_epi8(__m256i first, __m256i second) {
 INTGEMM_AVX2 static inline void storeu_ps(float* mem_addr, __m256 a) {
   _mm256_storeu_ps(mem_addr, a);
 }
-INTGEMM_AVX2 static inline __m256 add_ps (__m256 a, __m256 b) {
-  return _mm256_add_ps(a, b);
+INTGEMM_AVX2 static inline __m256 sub_ps(__m256 a, __m256 b) {
+  return _mm256_sub_ps(a, b);
 }
 
 /*
@@ -164,6 +188,9 @@ INTGEMM_AVX512BW static inline __m512i add_epi32(__m512i first, __m512i second) 
 INTGEMM_AVX512BW static inline __m512i adds_epi16(__m512i first, __m512i second) {
   return _mm512_adds_epi16(first, second);
 }
+INTGEMM_AVX512BW static inline __m512 add_ps(__m512 a, __m512 b) {
+  return _mm512_add_ps(a, b);
+}
 INTGEMM_AVX512DQ static inline __m512 and_ps(__m512 first, __m512 second) {
   return _mm512_and_ps(first, second);
 }
@@ -172,6 +199,12 @@ INTGEMM_AVX512BW static inline __m512 cvtepi32_ps(__m512i arg) {
 }
 INTGEMM_AVX512BW static inline __m512i cvtps_epi32(__m512 arg) {
   return _mm512_cvtps_epi32(arg);
+}
+INTGEMM_AVX512BW static inline __m512i cvttps_epi32(__m512 a) {
+  return _mm512_cvttps_epi32(a);
+}
+INTGEMM_AVX512BW static inline __m512 i32gather_ps(float const *base_addr, __m512i vindex, const int scale) {
+  return _mm512_i32gather_ps(vindex, base_addr, scale);
 }
 template <> INTGEMM_AVX512BW inline __m512 loadu_ps(const float* mem_addr) {
   return _mm512_loadu_ps(mem_addr);
@@ -185,8 +218,8 @@ INTGEMM_AVX512BW static inline __m512i maddubs_epi16(__m512i first, __m512i seco
 INTGEMM_AVX512BW static inline __m512 max_ps(__m512 first, __m512 second) {
   return _mm512_max_ps(first, second);
 }
-INTGEMM_AVX512BW static inline __m512 add_ps(__m512 first, __m512 second) {
-  return _mm512_add_ps(first, second);
+INTGEMM_AVX512BW static inline __m512 min_ps(__m512 a, __m512 b) {
+  return _mm512_min_ps(a, b);
 }
 INTGEMM_AVX512BW static inline __m512 mul_ps(__m512 a, __m512 b) {
   return _mm512_mul_ps(a, b);
@@ -211,6 +244,9 @@ template <> INTGEMM_AVX512BW inline __m512i setzero_si<__m512i>() {
  */
 INTGEMM_AVX512BW static inline void storeu_ps(float* mem_addr, __m512 a) {
   _mm512_storeu_ps(mem_addr, a);
+}
+INTGEMM_AVX512BW static inline __m512 sub_ps(__m512 a, __m512 b) {
+  return _mm512_sub_ps(a, b);
 }
 
 #endif

--- a/postprocess.h
+++ b/postprocess.h
@@ -250,4 +250,45 @@ public:
   }
 };
 
+/*
+ * Tanh (uses Taylor series approximation of e^x)
+ */
+class Tanh {};
+
+template <>
+class PostprocessImpl<Tanh, CPUType::AVX2> {
+public:
+  using InputRegister = __m256;
+  using OutputRegister = __m256;
+
+  PostprocessImpl(const Tanh& config) {}
+
+  INTGEMM_AVX2 inline OutputRegister run(InputRegister input, Index offset) {
+    const static auto const_zero = setzero_ps<__m256>();
+
+    auto e_x = exp_approx_taylor(input);
+    auto e_minus_x = exp_approx_taylor(sub_ps(const_zero, input));
+
+    return div_ps(sub_ps(e_x, e_minus_x), add_ps(e_x, e_minus_x));
+  }
+};
+
+template <>
+class PostprocessImpl<Tanh, CPUType::AVX512BW> {
+public:
+  using InputRegister = __m512;
+  using OutputRegister = __m512;
+
+  PostprocessImpl(const Tanh& config) {}
+
+  INTGEMM_AVX512BW inline OutputRegister run(InputRegister input, Index offset) {
+    const static auto const_zero = setzero_ps<__m512>();
+
+    auto e_x = exp_approx_taylor(input);
+    auto e_minus_x = exp_approx_taylor(sub_ps(const_zero, input));
+
+    return div_ps(sub_ps(e_x, e_minus_x), add_ps(e_x, e_minus_x));
+  }
+};
+
 }

--- a/test/multiply_test.cc
+++ b/test/multiply_test.cc
@@ -61,7 +61,7 @@ INTGEMM_SSE2 TEST_CASE("Transpose 16", "[transpose]") {
   SlowTranspose(input.begin(), ref.begin(), N, N);
 
   // Overwrite input.
-  __m128i *t = reinterpret_cast<__m128i*>(input.begin());
+  __m128i *t = input.as<__m128i>();
   Transpose16InLane(t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7]);
 
   for (int16_t i = 0; i < input.size(); ++i) {
@@ -79,7 +79,7 @@ INTGEMM_SSSE3 TEST_CASE("Transpose 8", "[transpose]") {
   SlowTranspose(input.begin(), ref.begin(), N, N);
 
   // Overwrite input.
-  __m128i *t = reinterpret_cast<__m128i*>(input.begin());
+  __m128i *t = input.as<__m128i>();
   Transpose8InLane(t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7], t[8], t[9], t[10], t[11], t[12], t[13], t[14], t[15]);
 
   for (int i = 0; i < input.size(); ++i) {

--- a/test/relu_test.cc
+++ b/test/relu_test.cc
@@ -1,4 +1,5 @@
 #include "3rd_party/catch.hpp"
+#include "aligned.h"
 #include "postprocess.h"
 
 #include <numeric>
@@ -9,47 +10,45 @@ INTGEMM_SSE2 TEST_CASE("ReLU SSE2",) {
   if (kCPU < CPUType::SSE2)
     return;
 
-  float raw_input[8];
-  std::iota(raw_input, raw_input + 8, -2);
-
-  RegisterPair128 input;
-  input.pack0123 = *reinterpret_cast<__m128*>(raw_input);
-  input.pack4567 = *reinterpret_cast<__m128*>(raw_input + 4);
+  AlignedVector<float> input(8);
+  AlignedVector<float> output(8);
+  std::iota(input.begin(), input.end(), -2);
 
   auto postproc = PostprocessImpl<ReLU, CPUType::SSE2>(ReLU());
-  auto output = postproc.run(input, 0);
-  auto raw_output = reinterpret_cast<float*>(&output);
+  auto output_tmp = postproc.run({input.as<__m128>()[0], input.as<__m128>()[1]}, 0);
+  output.as<__m128>()[0] = output_tmp.pack0123;
+  output.as<__m128>()[1] = output_tmp.pack4567;
 
-  CHECK(raw_output[0] == 0.f); // input = -2
-  CHECK(raw_output[1] == 0.f); // input = -1
-  CHECK(raw_output[2] == 0.f); // input =  0
-  CHECK(raw_output[3] == 1.f); // input =  1
-  CHECK(raw_output[4] == 2.f); // input =  2
-  CHECK(raw_output[5] == 3.f); // input =  3
-  CHECK(raw_output[6] == 4.f); // input =  4
-  CHECK(raw_output[7] == 5.f); // input =  5
+  CHECK(output[0] == 0.f); // input = -2
+  CHECK(output[1] == 0.f); // input = -1
+  CHECK(output[2] == 0.f); // input =  0
+  CHECK(output[3] == 1.f); // input =  1
+  CHECK(output[4] == 2.f); // input =  2
+  CHECK(output[5] == 3.f); // input =  3
+  CHECK(output[6] == 4.f); // input =  4
+  CHECK(output[7] == 5.f); // input =  5
 }
 
 INTGEMM_AVX2 TEST_CASE("ReLU AVX2",) {
   if (kCPU < CPUType::AVX2)
     return;
 
-  float raw_input[8];
-  std::iota(raw_input, raw_input + 8, -4);
+  AlignedVector<float> input(8);
+  AlignedVector<float> output(8);
 
-  auto input = *reinterpret_cast<__m256*>(raw_input);
+  std::iota(input.begin(), input.end(), -4);
+
   auto postproc = PostprocessImpl<ReLU, CPUType::AVX2>(ReLU());
-  auto output = postproc.run(input, 0);
-  auto raw_output = reinterpret_cast<float*>(&output);
+  *output.as<__m256>() = postproc.run(*input.as<__m256>(), 0);
 
-  CHECK(raw_output[0] == 0.f); // input = -4
-  CHECK(raw_output[1] == 0.f); // input = -3
-  CHECK(raw_output[2] == 0.f); // input = -2
-  CHECK(raw_output[3] == 0.f); // input = -1
-  CHECK(raw_output[4] == 0.f); // input =  0
-  CHECK(raw_output[5] == 1.f); // input =  1
-  CHECK(raw_output[6] == 2.f); // input =  2
-  CHECK(raw_output[7] == 3.f); // input =  3
+  CHECK(output[0] == 0.f); // input = -4
+  CHECK(output[1] == 0.f); // input = -3
+  CHECK(output[2] == 0.f); // input = -2
+  CHECK(output[3] == 0.f); // input = -1
+  CHECK(output[4] == 0.f); // input =  0
+  CHECK(output[5] == 1.f); // input =  1
+  CHECK(output[6] == 2.f); // input =  2
+  CHECK(output[7] == 3.f); // input =  3
 }
 
 #ifndef INTGEMM_NO_AVX512
@@ -58,30 +57,30 @@ INTGEMM_AVX512BW TEST_CASE("ReLU AVX512",) {
   if (kCPU < CPUType::AVX512BW)
     return;
 
-  float raw_input[16];
-  std::iota(raw_input, raw_input + 16, -8);
+  AlignedVector<float> input(16);
+  AlignedVector<float> output(16);
 
-  auto input = *reinterpret_cast<__m512*>(raw_input);
+  std::iota(input.begin(), input.end(), -8);
+
   auto postproc = PostprocessImpl<ReLU, CPUType::AVX512BW>(ReLU());
-  auto output = postproc.run(input, 0);
-  auto raw_output = reinterpret_cast<float*>(&output);
+  *output.as<__m512>() = postproc.run(*input.as<__m512>(), 0);
 
-  CHECK(raw_output[0]  == 0.f); // input = -8
-  CHECK(raw_output[1]  == 0.f); // input = -7
-  CHECK(raw_output[2]  == 0.f); // input = -6
-  CHECK(raw_output[3]  == 0.f); // input = -5
-  CHECK(raw_output[4]  == 0.f); // input = -4
-  CHECK(raw_output[5]  == 0.f); // input = -3
-  CHECK(raw_output[6]  == 0.f); // input = -2
-  CHECK(raw_output[7]  == 0.f); // input = -1
-  CHECK(raw_output[8]  == 0.f); // input =  0
-  CHECK(raw_output[9]  == 1.f); // input =  1
-  CHECK(raw_output[10] == 2.f); // input =  2
-  CHECK(raw_output[11] == 3.f); // input =  3
-  CHECK(raw_output[12] == 4.f); // input =  4
-  CHECK(raw_output[13] == 5.f); // input =  5
-  CHECK(raw_output[14] == 6.f); // input =  6
-  CHECK(raw_output[15] == 7.f); // input =  7
+  CHECK(output[0]  == 0.f); // input = -8
+  CHECK(output[1]  == 0.f); // input = -7
+  CHECK(output[2]  == 0.f); // input = -6
+  CHECK(output[3]  == 0.f); // input = -5
+  CHECK(output[4]  == 0.f); // input = -4
+  CHECK(output[5]  == 0.f); // input = -3
+  CHECK(output[6]  == 0.f); // input = -2
+  CHECK(output[7]  == 0.f); // input = -1
+  CHECK(output[8]  == 0.f); // input =  0
+  CHECK(output[9]  == 1.f); // input =  1
+  CHECK(output[10] == 2.f); // input =  2
+  CHECK(output[11] == 3.f); // input =  3
+  CHECK(output[12] == 4.f); // input =  4
+  CHECK(output[13] == 5.f); // input =  5
+  CHECK(output[14] == 6.f); // input =  6
+  CHECK(output[15] == 7.f); // input =  7
 }
 
 #endif

--- a/test/sigmoid_test.cc
+++ b/test/sigmoid_test.cc
@@ -1,4 +1,5 @@
 #include "3rd_party/catch.hpp"
+#include "aligned.h"
 #include "postprocess.h"
 
 #include <numeric>
@@ -17,22 +18,22 @@ INTGEMM_AVX2 TEST_CASE("Sigmoid AVX2",) {
 
   const float error_tolerance = 0.001f;
 
-  __m256 input;
-  auto raw = reinterpret_cast<float*>(&input);
-  std::iota(raw, raw + 8, -4);
+  AlignedVector<float> input(8);
+  AlignedVector<float> output(8);
+
+  std::iota(input.begin(), input.end(), -4);
 
   auto postproc = PostprocessImpl<Sigmoid, CPUType::AVX2>(Sigmoid());
-  auto output = postproc.run(input, 0);
-  auto raw_output = reinterpret_cast<float*>(&output);
+  *output.as<__m256>() = postproc.run(*input.as<__m256>(), 0);
 
-  CHECK_FLOAT(raw_output[0], 0.0179862f, error_tolerance); // input = -4
-  CHECK_FLOAT(raw_output[1], 0.0474259f, error_tolerance); // input = -3
-  CHECK_FLOAT(raw_output[2], 0.1192029f, error_tolerance); // input = -2
-  CHECK_FLOAT(raw_output[3], 0.2689414f, error_tolerance); // input = -1
-  CHECK_FLOAT(raw_output[4], 0.5f      , error_tolerance); // input =  0
-  CHECK_FLOAT(raw_output[5], 0.7310586f, error_tolerance); // input =  1
-  CHECK_FLOAT(raw_output[6], 0.8807970f, error_tolerance); // input =  2
-  CHECK_FLOAT(raw_output[7], 0.9525740f, error_tolerance); // input =  3
+  CHECK_FLOAT(output[0], 0.0179862f, error_tolerance); // input = -4
+  CHECK_FLOAT(output[1], 0.0474259f, error_tolerance); // input = -3
+  CHECK_FLOAT(output[2], 0.1192029f, error_tolerance); // input = -2
+  CHECK_FLOAT(output[3], 0.2689414f, error_tolerance); // input = -1
+  CHECK_FLOAT(output[4], 0.5f      , error_tolerance); // input =  0
+  CHECK_FLOAT(output[5], 0.7310586f, error_tolerance); // input =  1
+  CHECK_FLOAT(output[6], 0.8807970f, error_tolerance); // input =  2
+  CHECK_FLOAT(output[7], 0.9525740f, error_tolerance); // input =  3
 }
 
 }

--- a/test/sigmoid_test.cc
+++ b/test/sigmoid_test.cc
@@ -1,0 +1,38 @@
+#include "3rd_party/catch.hpp"
+#include "postprocess.h"
+
+#include <numeric>
+
+#define CHECK_FLOAT(actual, expected, epsilon) \
+  do { \
+    if (fabs((actual) - (expected)) < epsilon) { SUCCEED(); } \
+    else { CHECK((actual) == (expected)); } \
+  } while(0)
+
+namespace intgemm {
+
+INTGEMM_AVX2 TEST_CASE("Sigmoid AVX2",) {
+  if (kCPU < CPUType::AVX2)
+    return;
+
+  const float error_tolerance = 0.001f;
+
+  __m256 input;
+  auto raw = reinterpret_cast<float*>(&input);
+  std::iota(raw, raw + 8, -4);
+
+  auto postproc = PostprocessImpl<Sigmoid, CPUType::AVX2>(Sigmoid());
+  auto output = postproc.run(input, 0);
+  auto raw_output = reinterpret_cast<float*>(&output);
+
+  CHECK_FLOAT(raw_output[0], 0.0179862f, error_tolerance); // input = -4
+  CHECK_FLOAT(raw_output[1], 0.0474259f, error_tolerance); // input = -3
+  CHECK_FLOAT(raw_output[2], 0.1192029f, error_tolerance); // input = -2
+  CHECK_FLOAT(raw_output[3], 0.2689414f, error_tolerance); // input = -1
+  CHECK_FLOAT(raw_output[4], 0.5f      , error_tolerance); // input =  0
+  CHECK_FLOAT(raw_output[5], 0.7310586f, error_tolerance); // input =  1
+  CHECK_FLOAT(raw_output[6], 0.8807970f, error_tolerance); // input =  2
+  CHECK_FLOAT(raw_output[7], 0.9525740f, error_tolerance); // input =  3
+}
+
+}

--- a/test/tanh_test.cc
+++ b/test/tanh_test.cc
@@ -1,0 +1,42 @@
+#include "3rd_party/catch.hpp"
+#include "postprocess.h"
+
+#include <numeric>
+
+#define CHECK_FLOAT(actual, expected, epsilon) \
+  do { \
+    if (fabs((actual) - (expected)) < epsilon) { SUCCEED(); } \
+    else { CHECK((actual) == (expected)); } \
+  } while(0)
+
+namespace intgemm {
+
+INTGEMM_AVX2 TEST_CASE("Tanh AVX2",) {
+  if (kCPU < CPUType::AVX2)
+    return;
+
+  const float error_tolerance = 0.001f;
+
+  __m256 input;
+
+  { // fill
+    auto raw = reinterpret_cast<float*>(&input);
+    int n = -4;
+    std::generate(raw, raw + 8, [&n] () { return n++ / 4.f; });
+  }
+
+  auto postproc = PostprocessImpl<Tanh, CPUType::AVX2>(Tanh());
+  auto output = postproc.run(input, 0);
+  auto raw_output = reinterpret_cast<float*>(&output);
+
+  CHECK_FLOAT(raw_output[0], -0.7615942f, error_tolerance); // input = -1
+  CHECK_FLOAT(raw_output[1], -0.6351490f, error_tolerance); // input = -0.75
+  CHECK_FLOAT(raw_output[2], -0.4621172f, error_tolerance); // input = -0.5
+  CHECK_FLOAT(raw_output[3], -0.2449187f, error_tolerance); // input = -0.25
+  CHECK_FLOAT(raw_output[4],  0.0f      , error_tolerance); // input =  0
+  CHECK_FLOAT(raw_output[5],  0.2449187f, error_tolerance); // input =  0.25
+  CHECK_FLOAT(raw_output[6],  0.4621172f, error_tolerance); // input =  0.5
+  CHECK_FLOAT(raw_output[7],  0.6351490f, error_tolerance); // input =  0.75
+}
+
+}

--- a/test/tanh_test.cc
+++ b/test/tanh_test.cc
@@ -1,4 +1,5 @@
 #include "3rd_party/catch.hpp"
+#include "aligned.h"
 #include "postprocess.h"
 
 #include <numeric>
@@ -17,26 +18,22 @@ INTGEMM_AVX2 TEST_CASE("Tanh AVX2",) {
 
   const float error_tolerance = 0.001f;
 
-  __m256 input;
+  AlignedVector<float> input(8);
+  AlignedVector<float> output(8);
 
-  { // fill
-    auto raw = reinterpret_cast<float*>(&input);
-    int n = -4;
-    std::generate(raw, raw + 8, [&n] () { return n++ / 4.f; });
-  }
+  std::generate(input.begin(), input.end(), [] () { static int n = -4; return n++ / 4.f; });
 
   auto postproc = PostprocessImpl<Tanh, CPUType::AVX2>(Tanh());
-  auto output = postproc.run(input, 0);
-  auto raw_output = reinterpret_cast<float*>(&output);
+  *output.as<__m256>() = postproc.run(*input.as<__m256>(), 0);
 
-  CHECK_FLOAT(raw_output[0], -0.7615942f, error_tolerance); // input = -1
-  CHECK_FLOAT(raw_output[1], -0.6351490f, error_tolerance); // input = -0.75
-  CHECK_FLOAT(raw_output[2], -0.4621172f, error_tolerance); // input = -0.5
-  CHECK_FLOAT(raw_output[3], -0.2449187f, error_tolerance); // input = -0.25
-  CHECK_FLOAT(raw_output[4],  0.0f      , error_tolerance); // input =  0
-  CHECK_FLOAT(raw_output[5],  0.2449187f, error_tolerance); // input =  0.25
-  CHECK_FLOAT(raw_output[6],  0.4621172f, error_tolerance); // input =  0.5
-  CHECK_FLOAT(raw_output[7],  0.6351490f, error_tolerance); // input =  0.75
+  CHECK_FLOAT(output[0], -0.7615942f, error_tolerance); // input = -1
+  CHECK_FLOAT(output[1], -0.6351490f, error_tolerance); // input = -0.75
+  CHECK_FLOAT(output[2], -0.4621172f, error_tolerance); // input = -0.5
+  CHECK_FLOAT(output[3], -0.2449187f, error_tolerance); // input = -0.25
+  CHECK_FLOAT(output[4],  0.0f      , error_tolerance); // input =  0
+  CHECK_FLOAT(output[5],  0.2449187f, error_tolerance); // input =  0.25
+  CHECK_FLOAT(output[6],  0.4621172f, error_tolerance); // input =  0.5
+  CHECK_FLOAT(output[7],  0.6351490f, error_tolerance); // input =  0.75
 }
 
 }

--- a/utils.h
+++ b/utils.h
@@ -57,16 +57,16 @@ constexpr unsigned long long factorial(unsigned n) {
 }
 
 /*
- * e^x
+ * e^n, where n is integer
  */
 namespace { // anonymous namespace
-constexpr double exp_nonnegative(unsigned x) {
-  return x == 0 ? 1.0 : (x == 1 ? 2.718281828459045 : exp_nonnegative(x / 2) * exp_nonnegative((x + 1) / 2));
+constexpr double expi_nonnegative(unsigned n) {
+  return n == 0 ? 1.0 : (n == 1 ? 2.718281828459045 : expi_nonnegative(n / 2) * expi_nonnegative((n + 1) / 2));
 }
 } // anonymous namespace
 
-constexpr double exp(int x) {
-  return (x >= 0 ? exp_nonnegative(x) : 1.0 / exp_nonnegative(-x));
+constexpr double expi(int n) {
+  return (n >= 0 ? expi_nonnegative(n) : 1.0 / expi_nonnegative(-n));
 }
 
 }

--- a/utils.h
+++ b/utils.h
@@ -49,4 +49,11 @@ constexpr subtuple_t<Tuple, Indices...> make_subtuple(const Tuple& tuple, sequen
   return std::make_tuple(std::get<Indices>(tuple)...);
 }
 
+/*
+ * Factorial
+ */
+constexpr unsigned long long factorial(unsigned n) {
+  return n <= 1 ? 1 : n * factorial(n - 1);
+}
+
 }

--- a/utils.h
+++ b/utils.h
@@ -56,4 +56,17 @@ constexpr unsigned long long factorial(unsigned n) {
   return n <= 1 ? 1 : n * factorial(n - 1);
 }
 
+/*
+ * e^x
+ */
+namespace { // anonymous namespace
+constexpr double exp_nonnegative(unsigned x) {
+  return x == 0 ? 1.0 : (x == 1 ? 2.718281828459045 : exp_nonnegative(x / 2) * exp_nonnegative((x + 1) / 2));
+}
+} // anonymous namespace
+
+constexpr double exp(int x) {
+  return (x >= 0 ? exp_nonnegative(x) : 1.0 / exp_nonnegative(-x));
+}
+
 }

--- a/vec_utils.h
+++ b/vec_utils.h
@@ -75,13 +75,13 @@ Register exp_approx_taylor(Register x) {
   static constexpr int EXP_MIN = -20;
   static constexpr int EXP_MAX = 20;
   static constexpr float EXP_LOOKUP[EXP_MAX - EXP_MIN + 1] = {
-    exp(-20), exp(-19), exp(-18), exp(-17), exp(-16), exp(-15),
-    exp(-14), exp(-13), exp(-12), exp(-11), exp(-10), exp(-9),
-    exp(-8), exp(-7), exp(-6), exp(-5), exp(-4), exp(-3), exp(-2),
-    exp(-1), exp(0), exp(1), exp(2), exp(3), exp(4), exp(5),
-    exp(6), exp(7), exp(8), exp(9), exp(10), exp(11), exp(12),
-    exp(13), exp(14), exp(15), exp(16), exp(17), exp(18), exp(19),
-    exp(20),
+    expi(-20), expi(-19), expi(-18), expi(-17), expi(-16), expi(-15),
+    expi(-14), expi(-13), expi(-12), expi(-11), expi(-10), expi(-9),
+    expi(-8), expi(-7), expi(-6), expi(-5), expi(-4), expi(-3), expi(-2),
+    expi(-1), expi(0), expi(1), expi(2), expi(3), expi(4), expi(5),
+    expi(6), expi(7), expi(8), expi(9), expi(10), expi(11), expi(12),
+    expi(13), expi(14), expi(15), expi(16), expi(17), expi(18), expi(19),
+    expi(20),
   };
 
   static const Register dividers[] = {

--- a/vec_utils.h
+++ b/vec_utils.h
@@ -46,4 +46,86 @@ INTGEMM_AVX512BW static inline __m512 unquantize(__m512i input, __m512 unquantiz
 }
 #endif
 
+/*
+ *
+ * Calculate floor: float -> float
+ *
+ */
+INTGEMM_SSE2 static inline __m128 floor_ff(__m128 a) {
+  return cvtepi32_ps(_mm_cvttps_epi32(a));
+}
+INTGEMM_AVX2 static inline __m256 floor_ff(__m256 a) {
+  return _mm256_floor_ps(a);
+}
+#ifndef INTGEMM_NO_AVX512
+INTGEMM_AVX512BW static inline __m512 floor_ff(__m512 a) {
+  return cvtepi32_ps(cvttps_epi32(a)); // TODO: Is there any better way to do that?
+}
+#endif
+
+/*
+ *
+ * Calculate approximation of e^x using Taylor series and lookup table
+ *
+ */
+namespace { // anonymous namespace
+
+template <typename Register>
+Register exp_approx_taylor(Register x) {
+  static constexpr int EXP_MIN = -20;
+  static constexpr int EXP_MAX = 20;
+  static constexpr float EXP_LOOKUP[EXP_MAX - EXP_MIN + 1] = {
+    exp(-20), exp(-19), exp(-18), exp(-17), exp(-16), exp(-15),
+    exp(-14), exp(-13), exp(-12), exp(-11), exp(-10), exp(-9),
+    exp(-8), exp(-7), exp(-6), exp(-5), exp(-4), exp(-3), exp(-2),
+    exp(-1), exp(0), exp(1), exp(2), exp(3), exp(4), exp(5),
+    exp(6), exp(7), exp(8), exp(9), exp(10), exp(11), exp(12),
+    exp(13), exp(14), exp(15), exp(16), exp(17), exp(18), exp(19),
+    exp(20),
+  };
+
+  static const Register dividers[] = {
+    set1_ps<Register>(1.f / factorial(7)),
+    set1_ps<Register>(1.f / factorial(6)),
+    set1_ps<Register>(1.f / factorial(5)),
+    set1_ps<Register>(1.f / factorial(4)),
+    set1_ps<Register>(1.f / factorial(3)),
+    set1_ps<Register>(1.f / factorial(2)),
+    set1_ps<Register>(1.f / factorial(1)),
+  };
+  static const auto const_one = set1_ps<Register>(1.f);
+  static const auto const_min_x = set1_ps<Register>(EXP_MIN);
+  static const auto const_max_x = set1_ps<Register>(EXP_MAX);
+
+  x = max_ps(x, const_min_x);
+  x = min_ps(x, const_max_x);
+
+  auto a = floor_ff(x);
+  auto xa = sub_ps(x, a);
+
+  auto result = mul_ps(dividers[0], xa);
+
+  result = add_ps(result, dividers[1]);
+  result = mul_ps(result, xa);
+  result = add_ps(result, dividers[2]);
+  result = mul_ps(result, xa);
+  result = add_ps(result, dividers[3]);
+  result = mul_ps(result, xa);
+  result = add_ps(result, dividers[4]);
+  result = mul_ps(result, xa);
+  result = add_ps(result, dividers[5]);
+  result = mul_ps(result, xa);
+  result = add_ps(result, dividers[6]);
+  result = mul_ps(result, xa);
+
+  result = add_ps(result, const_one);
+
+  auto ea = i32gather_ps(EXP_LOOKUP + EXP_MAX, cvtps_epi32(a), 4);
+  return mul_ps(ea, result);
+}
+} // anonymous namespace
+
+template INTGEMM_AVX2 static __m256 exp_approx_taylor(__m256 x);
+template INTGEMM_AVX512BW static __m512 exp_approx_taylor(__m512 x);
+
 }


### PR DESCRIPTION
- Add sigmoid postprocess
- Add tanh postprocess
- Avoid reinterpret cast of float array to __mXXX type in tests because of possible problem with alignment