### PR TITLE
Intel Compiler Github Action

### DIFF
--- a/.github/workflows/intel-19.yml
+++ b/.github/workflows/intel-19.yml
@@ -1,27 +1,35 @@
-name: Intel 19.1 
+name: Intel Compiler 
 
 on:
   push:
     branches: [master, static]
   pull_request:
     branches: [master, static]
-
 jobs:
-  build:
-    runs-on: self-hosted
-
+  build_linux_apt_cpp:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v2
-    - name: environment
-      run: source /opt/intel/bin/compilervars.sh intel64 
+    - name: setup repo
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update 
+    - name: install
+      run: sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
     - name: cmake
       run: |
+        source /opt/intel/oneapi/setvars.sh
         mkdir -p build
         cd build
-        cmake  -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DCMAKE_BUILD_TYPE=Debug ..
+        cmake  -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc ..
     - name: Compile
       working-directory: build
       run: make -j2
     - name: Test
       working-directory: build
-      run: ctest -j2
+      run: ctest -j

--- a/.github/workflows/intel-19.yml
+++ b/.github/workflows/intel-19.yml
@@ -1,0 +1,27 @@
+name: Intel 19.1 
+
+on:
+  push:
+    branches: [master, static]
+  pull_request:
+    branches: [master, static]
+
+jobs:
+  build:
+    runs-on: self-hosted
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: environment
+      run: source /opt/intel/bin/compilervars.sh intel64 
+    - name: cmake
+      run: |
+        mkdir -p build
+        cd build
+        cmake  -DCMAKE_C_COMPILER=icc -DCMAKE_CXX_COMPILER=icpc -DCMAKE_BUILD_TYPE=Debug ..
+    - name: Compile
+      working-directory: build
+      run: make -j2
+    - name: Test
+      working-directory: build
+      run: ctest -j2

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![Build Ubuntu OpenMP](https://github.com/kpu/intgemm/workflows/Ubuntu%20OpenMP/badge.svg)
 ![Build Windows](https://github.com/kpu/intgemm/workflows/Windows/badge.svg)
 ![Build Mac](https://github.com/kpu/intgemm/workflows/Mac/badge.svg)
+![Build Mac](https://github.com/sidkashyap-at-Intel/intgemm/workflows/Intel%19/badge.svg)
 
 # Integer Matrix Multiplication
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Build Ubuntu OpenMP](https://github.com/kpu/intgemm/workflows/Ubuntu%20OpenMP/badge.svg)
 ![Build Windows](https://github.com/kpu/intgemm/workflows/Windows/badge.svg)
 ![Build Mac](https://github.com/kpu/intgemm/workflows/Mac/badge.svg)
-![Build Mac](https://github.com/sidkashyap-at-Intel/intgemm/workflows/Intel%19/badge.svg)
+![Intel Compilers](https://github.com/kpu/intgemm/workflows/Intel%2019.1/badge.svg)
 
 # Integer Matrix Multiplication
 


### PR DESCRIPTION
This PR adds .github/workflow/intel-19.yml to check the commit against Intel Compiler version 19.1

The runner needs to be 'self-hosted' as Intel Compilers are not available on Github runners. Easy to add a self-hosted runner by following the Github action settings guidelines. 

The runner daemon specific to kpu/intgemm will have to be started on var, has been tested on the forked repo. 

The README.md will have to change to kpu to update the compile badge. 

