### PR TITLE
Replaced __EMSCRIPTEN__ with WASM preprocessor directive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,11 @@ if (USE_OPENMP)
   target_link_libraries(intgemm PUBLIC OpenMP::OpenMP_CXX)
 endif()
 
+if (COMPILE_WASM)
+    # A compile defintion to compile intgemm on WASM platform
+    target_compile_definitions(intgemm PUBLIC WASM)
+endif()
+
 option(WORMHOLE "Use WASM wormhole https://bugzilla.mozilla.org/show_bug.cgi?id=1672160" OFF)
 if (WORMHOLE)
   target_compile_definitions(intgemm PUBLIC INTGEMM_WORMHOLE)

--- a/intgemm/intgemm.h
+++ b/intgemm/intgemm.h
@@ -49,7 +49,7 @@
 #include "avx512_gemm.h"
 #include "avx512vnni_gemm.h"
 
-#if defined(__EMSCRIPTEN__)
+#if defined(WASM)
 // No header for CPUID since it's hard-coded.
 #elif defined(__INTEL_COMPILER)
 #include <immintrin.h>
@@ -171,15 +171,15 @@ template <class T> T ChooseCPU(T
     avx2
 #endif
     , T ssse3, T
-#ifndef __EMSCRIPTEN__
+#ifndef WASM
     sse2
 #endif
     , T
-#ifndef __EMSCRIPTEN__
+#ifndef WASM
     unsupported
 #endif
     ) {
-#if defined(__EMSCRIPTEN__)
+#if defined(WASM)
   // emscripten does SSE4.1 but we only use up to SSSE3.
   return ssse3;
 #elif defined(__INTEL_COMPILER)


### PR DESCRIPTION
 - This will not break compilation to wasm platform while using
   a different toolchain than emscripten