### PR TITLE
Hacky nonmult8 for VNNI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ if(INTGEMM_DONT_BUILD_TESTS)
   return()
 endif()
 
-foreach(exe benchmark biasmultiply benchmark_quantizer)
+foreach(exe benchmark biasmultiply benchmark_quantizer non_mult_8)
   add_executable(${exe} benchmarks/${exe}.cc)
   target_link_libraries(${exe} intgemm)
 endforeach()

--- a/benchmarks/non_mult_8.cc
+++ b/benchmarks/non_mult_8.cc
@@ -145,5 +145,5 @@ int main() {
     //prepBtst<SSSE3::Kernels8>(32, 35);
     //prepBtst<AVX512VNNI::Kernels8>(64, 9);
     //padMatrixTst(32, 35);
-    smallMultTst<AVX512VNNI::Kernels8>(1, 64, 2);
+    smallMultTst<AVX512VNNI::Kernels8>(2, 64, 9);
 }

--- a/benchmarks/non_mult_8.cc
+++ b/benchmarks/non_mult_8.cc
@@ -145,5 +145,5 @@ int main() {
     //prepBtst<SSSE3::Kernels8>(32, 35);
     //prepBtst<AVX512VNNI::Kernels8>(64, 9);
     //padMatrixTst(32, 35);
-    smallMultTst<AVX512VNNI::Kernels8>(1, 64, 13);
+    smallMultTst<AVX512VNNI::Kernels8>(1, 64, 2);
 }

--- a/benchmarks/non_mult_8.cc
+++ b/benchmarks/non_mult_8.cc
@@ -1,0 +1,113 @@
+#include "../intgemm/aligned.h"
+#include "intgemm/intgemm_config.h"
+#include "../intgemm/avx512_gemm.h"
+#include "../intgemm/sse2_gemm.h"
+#include "../intgemm/avx2_gemm.h"
+#include "../intgemm/ssse3_gemm.h"
+#include "../intgemm/intgemm.h"
+#include "../intgemm/stats.h"
+#include "../intgemm/callbacks.h"
+#include <random>
+#include <iostream>
+
+/************************************************************************************ util ************************************************************************************/
+template <class T>
+int numDigits(T number) {
+    int digits = 0;
+    if (number <= 0) {
+      digits = 1; // count the minus and take care of the zero case
+    }
+    while (number) {
+        number /= 10;
+        digits++;
+    }
+    return digits;
+}
+
+template<class intType>
+void printMat(intType * a, size_t rows, size_t cols, std::string name, int digits = 0) {
+  std::cerr << name << std::endl;
+  for (size_t i = 0; i < rows; i++) {
+    for (size_t j = 0; j < cols; j++) {
+      int numbah = (int)a[i*cols + j];
+      // Pad for nice printing
+      int mydigits = digits - numDigits(numbah);
+      for (int t = 0; t < mydigits; t++) {
+        std::cerr << ' ';
+      }
+      std::cerr << numbah << " ";
+    }
+      std::cerr << std::endl;
+  }
+  std::cerr << std::endl;
+}
+
+template<class intType>
+void toColMajor(intType *in, intType * out, size_t rows, size_t cols) {
+  for (size_t i = 0; i < rows; i++) {
+    for (size_t j = 0; j < cols; j++) {
+      out[j*rows + i] = in[i*cols + j];
+    }
+  }
+}
+
+namespace intgemm {
+template <class Routine>
+void prepBtst(Index width, Index B_cols, float * in = nullptr) {
+  AlignedVector<float> B(width * B_cols);
+
+  //std::mt19937 gen;
+  //std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+  if (in != 0) {
+    for (Index i = 0; i<width*B_cols; i++) {
+      B[i] = in[i];
+    }
+  } else {
+    for (Index i = 0; i<width*B_cols; i++) {
+        B[i] = (float)(i%127);
+    }
+  }
+
+  
+
+  float alpha = 127.0f;
+  float quant_mult = 127.0f / alpha;
+  //float unquant_mult = 1.0f / (quant_mult*quant_mult);
+
+  printMat(B.begin(), width, B_cols, "Raw Mat", 4);
+
+  AlignedVector<int8_t> B_prep(B.size());
+  //AlignedVector<int8_t> B_prep_print(B.size());
+  Routine::PrepareB(B.begin(), B_prep.begin(), quant_mult, width, B_cols);
+  printMat(B_prep.begin(), B_cols, width, "Prep Mat", 3);
+
+
+  //toColMajor(B_prep.begin(), B_prep_print.begin(), B_cols, width);
+  //printMat(B_prep_print.begin(), B_cols, width, "Prep Mat trans", 3);
+
+}
+
+void padMatrixTst(Index width, Index B_cols) {
+    AlignedVector<float> B(width * B_cols);
+    std::div_t results = std::div(B_cols, 8);
+
+    for (Index i = 0; i<width*B_cols; i++) {
+      B[i] = (float)(i%127);
+    }
+    auto padded = padMatrix(B.begin(), width, B_cols);
+    printMat(B.begin(), width, B_cols, "Raw Mat", 4);
+    printMat(padded.begin(), width, 8, "Padded", 4);
+
+    auto shrunk = shrinkMat(B.begin(), width, B_cols);
+    printMat(shrunk.begin(), width, results.quot*8, "Remainder", 4);
+    prepBtst<SSSE3::Kernels8>(width, 8, padded.begin());
+}
+
+} // namespace intgemm;
+int main() {
+    using namespace intgemm;
+    //prepBtst<SSSE3::Kernels8>(32, 35);
+    prepBtst<SSSE3::Kernels8>(16, 3);
+    //padMatrixTst(32, 35);
+}

--- a/intgemm/aligned.h
+++ b/intgemm/aligned.h
@@ -39,7 +39,9 @@ template <class T> class AlignedVector {
     }
 
     AlignedVector(const AlignedVector&) = delete;
+    AlignedVector(AlignedVector&) = delete;
     AlignedVector& operator=(const AlignedVector&) = delete;
+    AlignedVector& operator=(AlignedVector&) = delete;
 
     ~AlignedVector() {
 #ifdef _MSC_VER

--- a/intgemm/avx512vnni_gemm.h
+++ b/intgemm/avx512vnni_gemm.h
@@ -83,6 +83,7 @@ struct Kernels8 : public AVX512BW::Kernels8 {
   template <typename Callback>
   INTGEMM_AVX512VNNI static void Multiply8Shift(const uint8_t *A, const int8_t *B, Index A_rows, Index width, Index B_cols, Callback callback) {
     assert(width % sizeof(Register) == 0);
+    //std::div_t results = std::div(B_cols, 8);
     assert(B_cols % 8 == 0);
     assert(reinterpret_cast<uintptr_t>(A) % sizeof(Register) == 0);
     assert(reinterpret_cast<uintptr_t>(B) % sizeof(Register) == 0);

--- a/intgemm/avx512vnni_gemm.h
+++ b/intgemm/avx512vnni_gemm.h
@@ -196,7 +196,7 @@ struct Kernels8 : public AVX512BW::Kernels8 {
     if (results.rem != 0) {
       const Register *B0_col = reinterpret_cast<const Register*>(B) + (B_cols_trimmed * width)/(sizeof(Register));
       const Register *B_live = B0_col; //In order to make the code look as much as possible as the above function
-      const Register *B_end = B_live + simd_width*8;
+      const Register *B_end = B_live + simd_width*results.rem;
 
       // TODO: separate first step.
       Register sum0 = zeros, sum1 = zeros, sum2 = zeros, sum3 = zeros, sum4 = zeros, sum5 = zeros, sum6 = zeros, sum7 = zeros;
@@ -209,7 +209,7 @@ struct Kernels8 : public AVX512BW::Kernels8 {
       Register pack0123 = Pack0123(sum0, sum1, sum2, sum3);
       Register pack4567 = Pack0123(sum4, sum5, sum6, sum7);
       auto total = PermuteSummer(pack0123, pack4567);
-      callback_impl.Run(total, callbacks::OutputBufferInfo(0, B0_colidx, 1, B_cols));
+      callback_impl.RunPartial(total, callbacks::OutputBufferInfo(0, B0_colidx, 1, B_cols), (Index)results.rem);
     }
   }
 

--- a/intgemm/avx512vnni_gemm.h
+++ b/intgemm/avx512vnni_gemm.h
@@ -83,16 +83,21 @@ struct Kernels8 : public AVX512BW::Kernels8 {
   template <typename Callback>
   INTGEMM_AVX512VNNI static void Multiply8Shift(const uint8_t *A, const int8_t *B, Index A_rows, Index width, Index B_cols, Callback callback) {
     assert(width % sizeof(Register) == 0);
-    //std::div_t results = std::div(B_cols, 8);
-    assert(B_cols % 8 == 0);
+    std::div_t results = std::div(B_cols, 8);
+    Index B_cols_trimmed = B_cols;
+    if (results.rem != 0) {
+      B_cols_trimmed = results.quot*8;
+    }
+    assert(B_cols_trimmed % 8 == 0);
     assert(reinterpret_cast<uintptr_t>(A) % sizeof(Register) == 0);
     assert(reinterpret_cast<uintptr_t>(B) % sizeof(Register) == 0);
     auto callback_impl = callbacks::CallbackImpl<CPUType::AVX2, Callback>(callback);
     const Index simd_width = width / sizeof(Register);
     Register zeros = setzero_si<Register>();
     // Go over 8 columns of B at a time.
+    Index B0_colidx = 0;
 #pragma omp for
-    for (Index B0_colidx = 0; B0_colidx < B_cols; B0_colidx += 8) {
+    for (; B0_colidx < B_cols_trimmed; B0_colidx += 8) {
       const Register *B0_col = reinterpret_cast<const Register*>(B) + B0_colidx * simd_width;
       // Process one row of A at a time.  Doesn't seem to be faster to do multiple rows of A at once.
       for (Index A_rowidx = 0; A_rowidx < A_rows; ++A_rowidx) {
@@ -120,20 +125,51 @@ struct Kernels8 : public AVX512BW::Kernels8 {
         callback_impl.Run(total, callbacks::OutputBufferInfo(A_rowidx, B0_colidx, A_rows, B_cols));
       }
     }
+    // Final bit, if we have a non-mult-of-eight matrix
+    if (results.rem != 0) {
+      const Register *B0_col = reinterpret_cast<const Register*>(B) + (B_cols_trimmed * width)/(sizeof(Register));
+      // Process one row of A at a time.  Doesn't seem to be faster to do multiple rows of A at once.
+      for (Index A_rowidx = 0; A_rowidx < A_rows; ++A_rowidx) {
+        // Iterate over shared (inner) dimension.
+        const Register *A_live = reinterpret_cast<const Register *>(A + A_rowidx * width);
+        const Register *A_end = A_live + simd_width;
+        const Register *B_live = B0_col;
+        // TODO: separate first step.
+        Register sum0 = zeros, sum1 = zeros, sum2 = zeros, sum3 = zeros, sum4 = zeros, sum5 = zeros, sum6 = zeros, sum7 = zeros;
+        Register * sums[8] = {&sum0, &sum1, &sum2, &sum3, &sum4, &sum5, &sum6, &sum7};
+        for (; A_live != A_end; ++A_live, B_live += results.rem) {
+          Register a = *A_live;
+          //MultiplyAdd
+          for (int i = 0; i < results.rem; i++) {
+            VNNI8(*sums[i], a,*(B_live + i));
+          }
+        }
+        Register pack0123 = Pack0123(sum0, sum1, sum2, sum3);
+        Register pack4567 = Pack0123(sum4, sum5, sum6, sum7);
+        auto total = PermuteSummer(pack0123, pack4567);
+        callback_impl.RunPartial(total, callbacks::OutputBufferInfo(A_rowidx, B0_colidx, A_rows, B_cols), (Index)results.rem);
+      }
+    }
   }
 
   template <typename Callback>
   INTGEMM_AVX512VNNI static void PrepareBias(const int8_t *B, Index width, Index B_cols, Callback callback) {
     assert(width % sizeof(Register) == 0);
-    assert(B_cols % 8 == 0);
+    std::div_t results = std::div(B_cols, 8);
+    Index B_cols_trimmed = B_cols;
+    if (results.rem != 0) {
+      B_cols_trimmed = results.quot*8;
+    }
+    assert(B_cols_trimmed % 8 == 0);
     assert(reinterpret_cast<uintptr_t>(B) % sizeof(Register) == 0);
     auto callback_impl = callbacks::CallbackImpl<CPUType::AVX2, Callback>(callback);
     Index simd_width = width / sizeof(Register);
     Register zeros = setzero_si<Register>();
     const Register a = set1_epi8<Register>(1);
     // Go over 8 columns of B at a time.
+    Index B0_colidx = 0;
 #pragma omp for
-    for (Index B0_colidx = 0; B0_colidx < B_cols; B0_colidx += 8) {
+    for (; B0_colidx < B_cols_trimmed; B0_colidx += 8) {
       const Register *B0_col = reinterpret_cast<const Register*>(B) + B0_colidx * simd_width;
       const Register *B_live = B0_col; //In order to make the code look as much as possible as the above function
       const Register *B_end = B_live + simd_width*8;
@@ -150,6 +186,25 @@ struct Kernels8 : public AVX512BW::Kernels8 {
         VNNI8(sum5, a, *(B_live + 5));
         VNNI8(sum6, a, *(B_live + 6));
         VNNI8(sum7, a, *(B_live + 7));
+      }
+      Register pack0123 = Pack0123(sum0, sum1, sum2, sum3);
+      Register pack4567 = Pack0123(sum4, sum5, sum6, sum7);
+      auto total = PermuteSummer(pack0123, pack4567);
+      callback_impl.Run(total, callbacks::OutputBufferInfo(0, B0_colidx, 1, B_cols));
+    }
+    // Final bit, if we have a non-mult-of-eight matrix
+    if (results.rem != 0) {
+      const Register *B0_col = reinterpret_cast<const Register*>(B) + (B_cols_trimmed * width)/(sizeof(Register));
+      const Register *B_live = B0_col; //In order to make the code look as much as possible as the above function
+      const Register *B_end = B_live + simd_width*8;
+
+      // TODO: separate first step.
+      Register sum0 = zeros, sum1 = zeros, sum2 = zeros, sum3 = zeros, sum4 = zeros, sum5 = zeros, sum6 = zeros, sum7 = zeros;
+      Register * sums[8] = {&sum0, &sum1, &sum2, &sum3, &sum4, &sum5, &sum6, &sum7};
+      for (; B_live != B_end; B_live += results.rem) {
+        for (int i = 0; i < results.rem; i++) {
+          VNNI8(*sums[i], a,*(B_live + i));
+        }
       }
       Register pack0123 = Pack0123(sum0, sum1, sum2, sum3);
       Register pack4567 = Pack0123(sum4, sum5, sum6, sum7);

--- a/intgemm/callbacks/implementations.inl
+++ b/intgemm/callbacks/implementations.inl
@@ -156,7 +156,7 @@ public:
     mult_reg = unquant_mult;
 #endif
     auto result = kernels::unquantize(input, mult_reg);
-    kernels::writePartial(result, config.output_addr, info.row_idx * info.cols + info.col_idx, partial);
+    kernels::write_partial(result, config.output_addr, info.row_idx * info.cols + info.col_idx, partial);
   }
 
 private:
@@ -184,7 +184,17 @@ public:
     auto result = kernels::relu<float>(kernels::unquantize(input, mult_reg));
     kernels::write(result, config.output_addr, info.row_idx * info.cols + info.col_idx);
   }
-  INTGEMM_TARGET void RunPartial(vi /*input*/, const OutputBufferInfo& /*info*/, Index /*partial*/) {}
+  INTGEMM_TARGET void RunPartial(vi input, const OutputBufferInfo& info, Index partial) {
+    // Workaround gcc 5 internal compiler error that can't read register members in debug.
+    vf mult_reg;
+#if !defined(__OPTIMIZE__) && (__GNUC__ == 5) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+    asm ("vmovdqa %1, %0" : "=x" (mult_reg) : "m" (unquant_mult));
+#else
+    mult_reg = unquant_mult;
+#endif
+    auto result = kernels::relu<float>(kernels::unquantize(input, mult_reg));
+    kernels::write_partial(result, config.output_addr, info.row_idx * info.cols + info.col_idx, partial);
+  }
 
 private:
   vf unquant_mult;
@@ -204,7 +214,10 @@ public:
     kernels::write(result, config.output_addr, info.row_idx * info.cols + info.col_idx);
   }
 
-  INTGEMM_TARGET void RunPartial(vi /*input*/, const OutputBufferInfo& /*info*/, Index /*partial*/) {}
+  INTGEMM_TARGET void RunPartial(vi input, const OutputBufferInfo& info, Index partial) {
+    auto result = kernels::add_bias_partial(input, config.bias_addr, info.col_idx, partial);
+    kernels::write_partial(result, config.output_addr, info.row_idx * info.cols + info.col_idx, partial);
+  }
 
 private:
   AddBiasAndWrite config;
@@ -231,7 +244,18 @@ public:
     result = kernels::add_bias(result, config.bias_addr, info.col_idx);
     kernels::write(result, config.output_addr, info.row_idx * info.cols + info.col_idx);
   }
-  INTGEMM_TARGET void RunPartial(vi /*input*/, const OutputBufferInfo& /*info*/, Index /*partial*/) {}
+  INTGEMM_TARGET void RunPartial(vi input, const OutputBufferInfo& info, Index partial) {
+    // Workaround gcc 5 internal compiler error that can't read register members in debug.
+    vf mult_reg;
+#if !defined(__OPTIMIZE__) && (__GNUC__ == 5) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+    asm ("vmovdqa %1, %0" : "=x" (mult_reg) : "m" (unquant_mult));
+#else
+    mult_reg = unquant_mult;
+#endif
+    auto result = kernels::unquantize(input, mult_reg);
+    result = kernels::add_bias_partial(result, config.bias_addr, info.col_idx, partial);
+    kernels::write_partial(result, config.output_addr, info.row_idx * info.cols + info.col_idx, partial);
+  }
 private:
   vf unquant_mult;
   UnquantizeAndAddBiasAndWrite config;
@@ -259,7 +283,19 @@ public:
     result = kernels::relu<float>(result);
     kernels::write(result, config.output_addr, info.row_idx * info.cols + info.col_idx);
   }
-  INTGEMM_TARGET void RunPartial(vi /*input*/, const OutputBufferInfo& /*info*/, Index /*partial*/) {}
+  INTGEMM_TARGET void RunPartial(vi input, const OutputBufferInfo& info, Index partial) {
+    // Workaround gcc 5 internal compiler error that can't read register members in debug.
+    vf mult_reg;
+#if !defined(__OPTIMIZE__) && (__GNUC__ == 5) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+    asm ("vmovdqa %1, %0" : "=x" (mult_reg) : "m" (unquant_mult));
+#else
+    mult_reg = unquant_mult;
+#endif
+    auto result = kernels::unquantize(input, mult_reg);
+    result = kernels::add_bias_partial(result, config.bias_addr, info.col_idx, partial);
+    result = kernels::relu<float>(result);
+    kernels::write_partial(result, config.output_addr, info.row_idx * info.cols + info.col_idx, partial);
+  }
 private:
   vf unquant_mult;
   UnquantizeAndAddBiasAndWriteRelu config;

--- a/intgemm/kernels/implementations.inl
+++ b/intgemm/kernels/implementations.inl
@@ -47,6 +47,39 @@ CPU_ATTR static inline void write(vd input, double* output, Index offset) {
 }
 
 /*
+ * Non-Vector write
+ */
+CPU_ATTR static inline void writePartial(vi input, int8_t* output, Index offset, Index partial) {
+  for (Index i = 0; i < partial; i++) {
+    *(output + offset + i) = input[i];
+  }
+}
+
+CPU_ATTR static inline void writePartial(vi input, int16_t* output, Index offset, Index partial) {
+  for (Index i = 0; i < partial; i++) {
+    *(output + offset + i) = input[i];
+  }
+}
+
+CPU_ATTR static inline void writePartial(vi input, int* output, Index offset, Index partial) {
+  for (Index i = 0; i < partial; i++) {
+    *(output + offset + i) = input[i];
+  }
+}
+
+CPU_ATTR static inline void writePartial(vf input, float* output, Index offset, Index partial) {
+  for (Index i = 0; i < partial; i++) {
+    *(output + offset + i) = input[i];
+  }
+}
+
+CPU_ATTR static inline void writePartial(vd input, double* output, Index offset, Index partial) {
+  for (Index i = 0; i < partial; i++) {
+    *(output + offset + i - 1) = input[i];
+  }
+}
+
+/*
  * Quantize
  */
 CPU_ATTR static inline vi quantize(vf input, vf quant_mult) {

--- a/intgemm/kernels/implementations.inl
+++ b/intgemm/kernels/implementations.inl
@@ -24,26 +24,31 @@ namespace intgemm {
 namespace kernels {
 
 /*
- * Write
+ * Write. Potentially unaligned memory, hence use storeu
  */
 CPU_ATTR static inline void write(vi input, int8_t* output, Index offset) {
-  *reinterpret_cast<vi*>(output + offset) = input;
+  storeu_ps(reinterpret_cast<float *>(output + offset), *reinterpret_cast<vf *>(&input));
+  //*reinterpret_cast<vi*>(output + offset) = input;
 }
 
 CPU_ATTR static inline void write(vi input, int16_t* output, Index offset) {
-  *reinterpret_cast<vi*>(output + offset) = input;
+  storeu_ps(reinterpret_cast<float *>(output + offset), *reinterpret_cast<vf *>(&input));
+  //*reinterpret_cast<vi*>(output + offset) = input;
 }
 
 CPU_ATTR static inline void write(vi input, int* output, Index offset) {
-  *reinterpret_cast<vi*>(output + offset) = input;
+  storeu_ps(reinterpret_cast<float *>(output + offset), *reinterpret_cast<vf *>(&input));
+  //*reinterpret_cast<vi*>(output + offset) = input;
 }
 
 CPU_ATTR static inline void write(vf input, float* output, Index offset) {
-  *reinterpret_cast<vf*>(output + offset) = input;
+  storeu_ps(reinterpret_cast<float *>(output + offset), input);
+  //*reinterpret_cast<vf*>(output + offset) = input;
 }
 
 CPU_ATTR static inline void write(vd input, double* output, Index offset) {
-  *reinterpret_cast<vd*>(output + offset) = input;
+  storeu_ps(reinterpret_cast<float *>(output + offset), *reinterpret_cast<vf *>(&input));
+  //*reinterpret_cast<vd*>(output + offset) = input;
 }
 
 /*

--- a/intgemm/kernels/implementations.inl
+++ b/intgemm/kernels/implementations.inl
@@ -49,31 +49,31 @@ CPU_ATTR static inline void write(vd input, double* output, Index offset) {
 /*
  * Non-Vector write
  */
-CPU_ATTR static inline void writePartial(vi input, int8_t* output, Index offset, Index partial) {
+CPU_ATTR static inline void write_partial(vi input, int8_t* output, Index offset, Index partial) {
   for (Index i = 0; i < partial; i++) {
     *(output + offset + i) = input[i];
   }
 }
 
-CPU_ATTR static inline void writePartial(vi input, int16_t* output, Index offset, Index partial) {
+CPU_ATTR static inline void write_partial(vi input, int16_t* output, Index offset, Index partial) {
   for (Index i = 0; i < partial; i++) {
     *(output + offset + i) = input[i];
   }
 }
 
-CPU_ATTR static inline void writePartial(vi input, int* output, Index offset, Index partial) {
+CPU_ATTR static inline void write_partial(vi input, int* output, Index offset, Index partial) {
   for (Index i = 0; i < partial; i++) {
     *(output + offset + i) = input[i];
   }
 }
 
-CPU_ATTR static inline void writePartial(vf input, float* output, Index offset, Index partial) {
+CPU_ATTR static inline void write_partial(vf input, float* output, Index offset, Index partial) {
   for (Index i = 0; i < partial; i++) {
     *(output + offset + i) = input[i];
   }
 }
 
-CPU_ATTR static inline void writePartial(vd input, double* output, Index offset, Index partial) {
+CPU_ATTR static inline void write_partial(vd input, double* output, Index offset, Index partial) {
   for (Index i = 0; i < partial; i++) {
     *(output + offset + i - 1) = input[i];
   }
@@ -118,6 +118,50 @@ CPU_ATTR static inline vf add_bias(vf input, const float* bias_addr, Index bias_
 
 CPU_ATTR static inline vd add_bias(vd input, const double* bias_addr, Index bias_offset) {
   auto bias_term = *reinterpret_cast<const vd*>(bias_addr + bias_offset);
+  return add_pd(input, bias_term);
+}
+
+/*
+ * Non vector bias add
+ */
+
+CPU_ATTR static inline vi add_bias_partial(vi input, const int8_t* bias_addr, Index bias_offset, Index partial) {
+  vi bias_term = set1_epi8<vi>(0);
+  for (Index i = 0; i<partial; i++) {
+    reinterpret_cast<int8_t *>(&bias_term)[i] = *(bias_addr + bias_offset + i);
+  }
+  return add_epi8(input, bias_term);
+}
+
+CPU_ATTR static inline vi add_bias_partial(vi input, const int16_t* bias_addr, Index bias_offset, Index partial) {
+  vi bias_term = set1_epi16<vi>(0);
+  for (Index i = 0; i<partial; i++) {
+    reinterpret_cast<int16_t *>(&bias_term)[i] = *(bias_addr + bias_offset + i);
+  }
+  return add_epi16(input, bias_term);
+}
+
+CPU_ATTR static inline vi add_bias_partial(vi input, const int* bias_addr, Index bias_offset, Index partial) {
+  vi bias_term = set1_epi32<vi>(0);
+  for (Index i = 0; i<partial; i++) {
+    reinterpret_cast<int32_t *>(&bias_term)[i] = *(bias_addr + bias_offset + i);
+  }
+  return add_epi32(input, bias_term);
+}
+
+CPU_ATTR static inline vf add_bias_partial(vf input, const float* bias_addr, Index bias_offset, Index partial) {
+  vf bias_term = set1_ps<vf>(0);
+  for (Index i = 0; i<partial; i++) {
+    reinterpret_cast<float *>(&bias_term)[i] = *(bias_addr + bias_offset + i);
+  }
+  return add_ps(input, bias_term);
+}
+
+CPU_ATTR static inline vd add_bias_partial(vd input, const double* bias_addr, Index bias_offset, Index partial) {
+  vd bias_term = set1_pd<vd>(0);
+  for (Index i = 0; i<partial; i++) {
+    reinterpret_cast<double *>(&bias_term)[i] = *(bias_addr + bias_offset + i);
+  }
   return add_pd(input, bias_term);
 }
 

--- a/test/add127_test.cc
+++ b/test/add127_test.cc
@@ -478,8 +478,12 @@ TEST_CASE ("Multiply AVX512F 8bit Shift vs Int", "[Add127]") {
 #ifdef INTGEMM_COMPILER_SUPPORTS_AVX512VNNI
 TEST_CASE ("Multiply AVX512VNNI 8bit Shift vs Int", "[Add127]") {
   if (kCPU < CPUType::AVX512VNNI) return;
+  TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 3, 0.0001f, 0.052f, 0.036f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 8, 0.0001f, 0.05f, 0.03f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 9, 0.0001f, 0.05f, 0.03f, 0.0001f);
+  TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 13, 0.0001f, 0.05f, 0.03f, 0.0001f);
+  TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 83, 0.0001f, 0.077f, 0.032f, 0.0001f);
+  TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 256, 270, 0.0001f, 0.61f, 0.17f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(8, 256, 256, 0.0001f, 0.22f, 0.06f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(8, 2048, 256, 0.0001f, 0.61f, 0.17f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(320, 256, 256, 0.0001f, 0.27f, 0.06f, 0.0001f);

--- a/test/add127_test.cc
+++ b/test/add127_test.cc
@@ -484,8 +484,11 @@ TEST_CASE ("Multiply AVX512VNNI 8bit Shift vs Int", "[Add127]") {
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 13, 0.0001f, 0.05f, 0.03f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 83, 0.0001f, 0.077f, 0.032f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 256, 270, 0.0001f, 0.61f, 0.17f, 0.0001f);
+  TestMultiplyShiftInt<AVX512VNNI::Kernels8>(8, 256, 233, 0.0001f, 0.23f, 0.06f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(8, 256, 256, 0.0001f, 0.22f, 0.06f, 0.0001f);
+  TestMultiplyShiftInt<AVX512VNNI::Kernels8>(8, 256, 270, 0.0001f, 0.23f, 0.06f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(8, 2048, 256, 0.0001f, 0.61f, 0.17f, 0.0001f);
+  TestMultiplyShiftInt<AVX512VNNI::Kernels8>(320, 256, 211, 0.0001f, 0.27f, 0.06f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(320, 256, 256, 0.0001f, 0.27f, 0.06f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(472, 256, 256, 0.0001f, 0.33f, 0.06f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(248, 256, 256, 0.0001f, 0.27f, 0.06f, 0.0001f);

--- a/test/add127_test.cc
+++ b/test/add127_test.cc
@@ -479,6 +479,7 @@ TEST_CASE ("Multiply AVX512F 8bit Shift vs Int", "[Add127]") {
 TEST_CASE ("Multiply AVX512VNNI 8bit Shift vs Int", "[Add127]") {
   if (kCPU < CPUType::AVX512VNNI) return;
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 8, 0.0001f, 0.05f, 0.03f, 0.0001f);
+  TestMultiplyShiftInt<AVX512VNNI::Kernels8>(1, 64, 9, 0.0001f, 0.05f, 0.03f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(8, 256, 256, 0.0001f, 0.22f, 0.06f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(8, 2048, 256, 0.0001f, 0.61f, 0.17f, 0.0001f);
   TestMultiplyShiftInt<AVX512VNNI::Kernels8>(320, 256, 256, 0.0001f, 0.27f, 0.06f, 0.0001f);


### PR DESCRIPTION
It's not a _purr_ fect implementation, but it is a start...
This patch implements the following:

- PrepareB for arbitrary columns matrices for all architectures. The last non-multiple-of-eight-columns are prepared and compressed as a small independent **width** by 8 matrix, zero'ed blocks of **register_width** are stripped. Unfortunately, this is not done in place in the current implementation, and involves memory copying. This can be improved in the future. I am using some inlined functions that don't have `CPU_ATTR` set. as I was lazy. I hope that inlining means they would be generated with the proper ISA limitataions. Regardless, so far only VNNI multiply is implemented anyways.
- Avx512VNNI multiplication of matrices of arbitrary number of columns + tests. The multiplication proceeds as normal until it reaches the last non-multiple-of-eight column and then proceeds to do those in a separate loop. 

Example: If we have A = 2x64 matrix and B = 64x9, we will perform a multiplication first, of 2x64 times 64x8 and then 1x64 times 64x1 (to produce the last column)

Unfortunately, now that we can have matrices that have non-multiple-of-eight columns, but we no longer write the columns consecutively, we get unaligned memory access when writing and we segfault. For this reason I have replaced the store routine with storeu.

Preliminary performance benchmarks with the builtin https://github.com/kpu/intgemm/blob/6228d016ecc63470d2dbb76bd4ab7b0abe097993/benchmarks/biasmultiply.cc#L267 to check for any performance regressions. (This is **not** including irregularly shaped non-multiple-of-8 matrices)
This branch (n=1)
```
taskset --cpu-list 0 ./biasmultiply
1000 iterations of SSSE3 without bias took: 2.31014 seconds.
1000 iterations of SSSE3 took: 2.39446 seconds.
1000 iterations of Shifted SSSE3 took: 1.98965 seconds.
1000 iterations of AVX2 without bias took: 1.33628 seconds.
1000 iterations of AVX2 took: 1.33306 seconds.
1000 iterations of Shifted AVX2 took: 1.20668 seconds.
1000 iterations of AVX512 without bias took: 1.01728 seconds.
1000 iterations of AVX512 took: 1.04101 seconds.
1000 iterations of Shifted AVX512 took: 0.779364 seconds.
1000 iterations of AVX512VNNI without bias took: 0.754878 seconds.
1000 iterations of AVX512VNNI took: 0.771353 seconds.
1000 iterations of Shifted AVX512VNNI took: 0.539761 seconds.
```
Master (n=1)
```
taskset --cpu-list 0 ./biasmultiply
1000 iterations of SSSE3 without bias took: 2.31003 seconds.
1000 iterations of SSSE3 took: 2.37843 seconds.
1000 iterations of Shifted SSSE3 took: 1.97674 seconds.
1000 iterations of AVX2 without bias took: 1.28795 seconds.
1000 iterations of AVX2 took: 1.33322 seconds.
1000 iterations of Shifted AVX2 took: 1.20815 seconds.
1000 iterations of AVX512 without bias took: 1.01804 seconds.
1000 iterations of AVX512 took: 1.06707 seconds.
1000 iterations of Shifted AVX512 took: 0.779698 seconds.
1000 iterations of AVX512VNNI without bias took: 0.776488 seconds.
1000 iterations of AVX512VNNI took: 0.772831 seconds.
1000 iterations of Shifted AVX512VNNI took: 0.653334 seconds.
```

Speed seems to be even better, but I don't trust that. Maybe some of the instruction reordering makes the benchmark perform better. I will have test it in a real world situation later on. 