### PR TITLE
Change some _MSC_VER to _WIN32

### DIFF
--- a/compile_test/avx2.cc
+++ b/compile_test/avx2.cc
@@ -1,7 +1,15 @@
 // Some compilers don't have AVX2 support.  Test for them.
 #include <immintrin.h>
 
-#if defined(_MSC_VER)
+// clang-cl bug doesn't include these headers when pretending to be MSVC
+// https://github.com/llvm/llvm-project/blob/e9a294449575a1e1a0daca470f64914695dc9adc/clang/lib/Headers/immintrin.h#L69-L72
+#if defined(_MSC_VER) && defined(__clang__)
+#include <avxintrin.h>
+#include <avx2intrin.h>
+#include <smmintrin.h>
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
 #define INTGEMM_AVX2
 #else
 #define INTGEMM_AVX2 __attribute__ ((target ("avx2")))

--- a/compile_test/avx512bw.cc
+++ b/compile_test/avx512bw.cc
@@ -1,7 +1,18 @@
 // Some compilers don't have AVX512BW support.  Test for them.
 #include <immintrin.h>
 
-#if defined(_MSC_VER)
+// clang-cl bug doesn't include these headers when pretending to be MSVC
+// https://github.com/llvm/llvm-project/blob/e9a294449575a1e1a0daca470f64914695dc9adc/clang/lib/Headers/immintrin.h#L69-L72
+#if defined(_MSC_VER) && defined(__clang__)
+#include <avxintrin.h>
+#include <avx2intrin.h>
+#include <smmintrin.h>
+#include <avx512fintrin.h>
+#include <avx512dqintrin.h>
+#include <avx512bwintrin.h>
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
 #define INTGEMM_AVX512BW
 #elif defined(__INTEL_COMPILER)
 #define INTGEMM_AVX512BW __attribute__ ((target ("avx512f")))

--- a/compile_test/avx512vnni.cc
+++ b/compile_test/avx512vnni.cc
@@ -1,6 +1,18 @@
 #include <immintrin.h>
 
-#if defined(_MSC_VER)
+// clang-cl bug doesn't include these headers when pretending to be MSVC
+// https://github.com/llvm/llvm-project/blob/e9a294449575a1e1a0daca470f64914695dc9adc/clang/lib/Headers/immintrin.h#L69-L72
+#if defined(_MSC_VER) && defined(__clang__)
+#include <avxintrin.h>
+#include <avx2intrin.h>
+#include <smmintrin.h>
+#include <avx512fintrin.h>
+#include <avx512dqintrin.h>
+#include <avx512bwintrin.h>
+#include <avx512vnniintrin.h>
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
 #elif defined(__INTEL_COMPILER)
 __attribute__ ((target ("avx512f")))
 #else

--- a/intgemm/intgemm.cc
+++ b/intgemm/intgemm.cc
@@ -117,7 +117,7 @@ CPUType GetCPUID() {
 const CPUType kCPU = GetCPUID();
 
 void UnsupportedCPUError() {
-#if defined(_MSC_VER) ? defined(_HAS_EXCEPTIONS) : defined(__EXCEPTIONS)
+#if (defined(_MSC_VER) && !defined(__clang__)) ? defined(_HAS_EXCEPTIONS) : defined(__EXCEPTIONS)
   throw UnsupportedCPU();
 #else
   std::cerr << "intgemm does not support this CPU" << std::endl;

--- a/intgemm/types.h
+++ b/intgemm/types.h
@@ -7,9 +7,22 @@
 #endif
 #include <emmintrin.h>
 
-#if defined(_MSC_VER) || defined(__INTEL_COMPILER)
-/* MSVC does not appear to have target attributes but is also fine with just
- * using intrinsics anywhere.
+// clang-cl bug doesn't include these headers when pretending to be MSVC
+// https://github.com/llvm/llvm-project/blob/e9a294449575a1e1a0daca470f64914695dc9adc/clang/lib/Headers/immintrin.h#L69-L72
+#if defined(_MSC_VER) && defined(__clang__)
+#include <avxintrin.h>
+#include <avx2intrin.h>
+#include <smmintrin.h>
+#include <avx512fintrin.h>
+#include <avx512dqintrin.h>
+#include <avx512bwintrin.h>
+#include <avx512vnniintrin.h>
+#endif
+
+#if (defined(_MSC_VER) && !defined(__clang__)) || defined(__INTEL_COMPILER)
+/* Real MSVC does not appear to have target attributes but is also fine with
+ * just using intrinsics anywhere.  clang-cl pretending to be MSVC requires
+ * target attributes, so it's excluded from the above.
  *
  * The Intel compiler has a bug whereby constructors with target attributes do
  * not link.  Like this program doesn't compile with icpc:


### PR DESCRIPTION
Intended to support Firefox compiling for Windows using Linux.  