### PR TITLE
Robust #if directive to activate/disable exception code

### DIFF
--- a/intgemm/aligned.h
+++ b/intgemm/aligned.h
@@ -5,7 +5,7 @@
 #include <malloc.h>
 #endif
 
-#if defined(_MSC_VER) ? !defined(_HAS_EXCEPTIONS) : !defined(__EXCEPTIONS)
+#if defined(_MSC_VER) ? !_HAS_EXCEPTIONS : !__EXCEPTIONS
 #include <cstdlib>
 #endif
 
@@ -22,15 +22,15 @@ template <class T> class AlignedVector {
 #ifdef _MSC_VER
       mem_ = static_cast<T*>(_aligned_malloc(size * sizeof(T), alignment));
       if (!mem_) {
-#  ifdef __EXCEPTIONS
+#  if _HAS_EXCEPTIONS != 0
         throw std::bad_alloc();
 #  else
         std::abort();
 #  endif
       }
-#else      
+#else
       if (posix_memalign(reinterpret_cast<void **>(&mem_), alignment, size * sizeof(T))) {
-#  ifdef __EXCEPTIONS
+#  if __EXCEPTIONS != 0
         throw std::bad_alloc();
 #  else
         std::abort();

--- a/intgemm/intgemm.cc
+++ b/intgemm/intgemm.cc
@@ -117,7 +117,7 @@ CPUType GetCPUID() {
 const CPUType kCPU = GetCPUID();
 
 void UnsupportedCPUError() {
-#if defined(_MSC_VER) ? defined(_HAS_EXCEPTIONS) : defined(__EXCEPTIONS)
+#if defined(_MSC_VER) ? (_HAS_EXCEPTIONS != 0) : (__EXCEPTIONS != 0)
   throw UnsupportedCPU();
 #else
   std::cerr << "intgemm does not support this CPU" << std::endl;


### PR DESCRIPTION
Passing `-D_HAS_EXCEPTIONS=0` in compilation flag causes `defined(_HAS_EXCEPTIONS)` to evaluate to `true`.

Here, a more robust check is introduced.

@kpu Earlier, if `_HAS_EXCEPTIONS` or `__EXCEPTIONS` was

Not defined -> exceptions off
Defined to 0 -> exceptions on
Defined to 1 (or any non-zero value) -> exceptions on

Now,
Not defined -> exceptions off
Defined to 0 -> exceptions **off**
Defined to 1 (or any non-zero value) -> exceptions on