### PR TITLE
Push C++ standard to 17 and add MinAbsolute to complement MaxAbsolute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 if(MSVC)
   add_compile_options(/W4 /WX)

--- a/intgemm/intgemm.cc
+++ b/intgemm/intgemm.cc
@@ -136,6 +136,11 @@ float Unsupported_MaxAbsolute(const float * /*begin*/, const float * /*end*/) {
   return 0.0f;
 }
 
+float Unsupported_MinAbsolute(const float * /*begin*/, const float * /*end*/) {
+  UnsupportedCPUError();
+  return 0.0f;
+}
+
 MeanStd Unsupported_VectorMeanStd(const float * /*begin*/, const float * /*end*/, bool /*absolute*/) {
   UnsupportedCPUError();
   return MeanStd();
@@ -185,6 +190,8 @@ using AVX2::VectorMeanStd;
 #endif
 
 float (*const MaxAbsolute)(const float *begin, const float *end) = ChooseCPU(AVX512BW::MaxAbsolute, AVX512BW::MaxAbsolute, AVX2::MaxAbsolute, SSE2::MaxAbsolute, SSE2::MaxAbsolute, Unsupported_MaxAbsolute);
+
+float (*const MinAbsolute)(const float *begin, const float *end) = ChooseCPU(AVX512BW::MinAbsolute, AVX512BW::MinAbsolute, AVX2::MinAbsolute, SSE2::MinAbsolute, SSE2::MinAbsolute, Unsupported_MinAbsolute);
 
 MeanStd (*const VectorMeanStd)(const float *begin, const float *end, bool absolute) = ChooseCPU(AVX512BW::VectorMeanStd, AVX512BW::VectorMeanStd, AVX2::VectorMeanStd, SSE2::VectorMeanStd, SSE2::VectorMeanStd, Unsupported_VectorMeanStd);
 

--- a/intgemm/intgemm.h
+++ b/intgemm/intgemm.h
@@ -352,6 +352,9 @@ extern const CPUType kCPU;
 // Get the maximum absolute value of an array of floats. The number of floats must be a multiple of 16 and 64-byte aligned.
 extern float (*const MaxAbsolute)(const float *begin, const float *end);
 
+// Get the maximum absolute value of an array of floats. The number of floats must be a multiple of 16 and 64-byte aligned.
+extern float (*const MinAbsolute)(const float *begin, const float *end);
+
 // Get a Quantization value that is equant to the mean of the data +N standard deviations. Use 2 by default
 extern MeanStd (*const VectorMeanStd)(const float *begin, const float *end, bool);
 

--- a/intgemm/stats.h
+++ b/intgemm/stats.h
@@ -21,6 +21,16 @@ INTGEMM_SSE2 static inline float MaxFloat32(__m128 a) {
   // This casting compiles to nothing.
   return *reinterpret_cast<float*>(&a);
 }
+INTGEMM_SSE2 static inline float MinFloat32(__m128 a) {
+  // Fold to just using the first 64 bits.
+  __m128 second_half = _mm_shuffle_ps(a, a, 3 * 4 + 2);
+  a = _mm_min_ps(a, second_half);
+  // Fold to just using the first 32 bits.
+  second_half = _mm_shuffle_ps(a, a, 1);
+  a = _mm_min_ps(a, second_half);
+  // This casting compiles to nothing.
+  return *reinterpret_cast<float*>(&a);
+}
 INTGEMM_SSE2 static inline float AddFloat32(__m128 a) {
   // Fold to just using the first 64 bits.
   __m128 second_half = _mm_shuffle_ps(a, a, 3 * 4 + 2);
@@ -36,6 +46,9 @@ INTGEMM_SSE2 static inline float AddFloat32(__m128 a) {
 INTGEMM_AVX2 static inline float MaxFloat32(__m256 a) {
   return MaxFloat32(max_ps(_mm256_castps256_ps128(a), _mm256_extractf128_ps(a, 1)));
 }
+INTGEMM_AVX2 static inline float MinFloat32(__m256 a) {
+  return MinFloat32(min_ps(_mm256_castps256_ps128(a), _mm256_extractf128_ps(a, 1)));
+}
 INTGEMM_AVX2 static inline float AddFloat32(__m256 a) {
   return AddFloat32(add_ps(_mm256_castps256_ps128(a), _mm256_extractf128_ps(a, 1)));
 }
@@ -48,6 +61,13 @@ INTGEMM_AVX512F static inline float MaxFloat32(__m512 a) {
   // So cast to pd, do AVX512F _mm512_extractf64x4_pd, then cast to ps.
   __m256 upper = _mm256_castpd_ps(_mm512_extractf64x4_pd(_mm512_castps_pd(a), 1));
   return MaxFloat32(max_ps(_mm512_castps512_ps256(a), upper));
+}
+// Find the minimum float.
+INTGEMM_AVX512F static inline float MinFloat32(__m512 a) {
+  // _mm512_extractf32x8_ps is AVX512DQ but we don't care about masking.
+  // So cast to pd, do AVX512F _mm512_extractf64x4_pd, then cast to ps.
+  __m256 upper = _mm256_castpd_ps(_mm512_extractf64x4_pd(_mm512_castps_pd(a), 1));
+  return MinFloat32(min_ps(_mm512_castps512_ps256(a), upper));
 }
 INTGEMM_AVX512F static inline float AddFloat32(__m512 a) {
   __m256 upper = _mm256_castpd_ps(_mm512_extractf64x4_pd(_mm512_castps_pd(a), 1));

--- a/test/multiply_test.cc
+++ b/test/multiply_test.cc
@@ -223,6 +223,31 @@ template <float (*Backend) (const float *, const float *)> void TestMaxAbsolute(
   }
 }
 
+void CompareMinAbs(const float *begin, const float *end, float test, std::size_t offset) {
+  float minabs = std::reduce(begin, end, begin[0], [&](float a, float b){return std::min(std::fabs(a), std::fabs(b));});
+  CHECK_MESSAGE(minabs == test, "Error: " << minabs << " versus " << test << " in length " << (end - begin) << " offset " << offset);
+}
+
+template <float (*Backend) (const float *, const float *)> void TestMinAbsolute() {
+  std::mt19937 gen;
+  std::uniform_real_distribution<float> dist(-8.0, 8.0);
+  const std::size_t kLengthMax = 65;
+  AlignedVector<float> test(kLengthMax);
+  for (std::size_t len = 1; len < kLengthMax; ++len) {
+    for (std::size_t t = 0; t < len; ++t) {
+      // Fill with [-8, 8).
+      for (auto& it : test) {
+        it = dist(gen);
+      }
+      CompareMinAbs(test.begin(), test.begin() + len, Backend(test.begin(), test.begin() + len), t);
+      test[t] = -32.0;
+      CompareMinAbs(test.begin(), test.begin() + len, Backend(test.begin(), test.begin() + len), t);
+      test[t] = 32.0;
+      CompareMinAbs(test.begin(), test.begin() + len, Backend(test.begin(), test.begin() + len), t);
+    }
+  }
+}
+
 TEST_CASE("MaxAbsolute SSE2", "[max]") {
   if (kCPU < CPUType::SSE2) return;
   TestMaxAbsolute<SSE2::MaxAbsolute>();
@@ -239,6 +264,25 @@ TEST_CASE("MaxAbsolute AVX2", "[max]") {
 TEST_CASE("MaxAbsolute AVX512BW", "[max]") {
   if (kCPU < CPUType::AVX512BW) return;
   TestMaxAbsolute<AVX512BW::MaxAbsolute>();
+}
+#endif
+
+TEST_CASE("MinAbsolute SSE2", "[min]") {
+  if (kCPU < CPUType::SSE2) return;
+  TestMinAbsolute<SSE2::MinAbsolute>();
+}
+
+#ifdef INTGEMM_COMPILER_SUPPORTS_AVX2
+TEST_CASE("MinAbsolute AVX2", "[min]") {
+  if (kCPU < CPUType::AVX2) return;
+  TestMinAbsolute<AVX2::MinAbsolute>();
+}
+#endif
+
+#ifdef INTGEMM_COMPILER_SUPPORTS_AVX512BW
+TEST_CASE("MinAbsolute AVX512BW", "[min]") {
+  if (kCPU < CPUType::AVX512BW) return;
+  TestMinAbsolute<AVX512BW::MinAbsolute>();
 }
 #endif
 


### PR DESCRIPTION
This PR does two things:
1) Changes the standard to C++17. Marian already uses that, there's no reason why we should continue with 11. gcc 5 supports almost the full C++17 anyways.
2) Adds `MinAbsolute` to complement `MaxAbsolute`. The purpose of this is to help me find which matrices will have shitty quantisation performance.